### PR TITLE
feat: search quality improvements — aliases, popular servers, official boost

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -144,8 +144,10 @@ server.tool(
   'search_mcp_servers',
   'Use when the user needs a capability you don\'t have. Search 5000+ MCP servers by keyword, use case, or technology from Official MCP Registry, Glama, and Smithery. Returns ranked results with install info.',
   {
-    query: z.string().describe(
-      'Search query — a keyword (e.g., "filesystem"), use case ("query databases"), or technology ("postgres")',
+    query: z.string().default('').describe(
+      'Search query — a keyword (e.g., "filesystem"), use case ("query databases"), or technology ("postgres"). ' +
+      'Common aliases work: "gh" → github, "pg" → postgres, "k8s" → kubernetes, "db" → database. ' +
+      'Leave empty to see the most popular servers.',
     ),
     limit: z.number().min(1).max(50).default(10).describe('Maximum results to return (default: 10, max: 50)'),
     transportType: z
@@ -198,7 +200,9 @@ server.tool(
       content: [
         {
           type: 'text' as const,
-          text: `Found ${results.length} MCP server(s) for "${query}":\n\n${formatted}\n\nUse get_server_details for full info, or get_install_command to generate install config for any platform.`,
+          text: query
+            ? `Found ${results.length} MCP server(s) for "${query}":\n\n${formatted}\n\nUse get_server_details for full info, or get_install_command to generate install config for any platform.`
+            : `Top ${results.length} most popular MCP servers:\n\n${formatted}\n\nUse search_mcp_servers with a query to find specific servers, or get_install_command to install any of these.`,
         },
       ],
     };


### PR DESCRIPTION
## Changes

### 1. Alias/semantic mapping for short names
- 30+ aliases: `gh` → github, `pg` → postgres, `k8s` → kubernetes, `db` → database, `js` → javascript nodejs, `fs` → filesystem, `aws` → amazon aws, etc.
- Aliases expand with OR logic in FTS5 for broader matching
- Before: `gh` returned Excel servers (matched author name). Now: GitHub #1

### 2. Empty query → top popular servers
- Empty query now returns most popular servers (official > verified > use_count)
- Before: returned error. Now: `Top 10 most popular MCP servers:`
- Good onboarding — users see what's available immediately

### 3. Configurable limit
- Already existed (1-50, default 10). Confirmed working.

### 4. Official servers ranking boost
- Official registry servers: 3.0x weight (15% of total score)
- Verified Smithery servers: 1.5x weight
- Before: `sentry` → Rust fork #1, official #2. Now: official #1

## Test Results
- `gh` → GitHub #1 ✅
- `pg` → Postgres servers ✅
- `k8s` → Kubernetes #1 ✅
- `js` → JavaScript/Node results (was 0 before!) ✅
- `sentry` → official getsentry/sentry-mcp is #1 ✅
- Empty query → popular servers list ✅
- All previous 44 tests still pass ✅