### PR TITLE
fix(core): make deprecation/archived enrichment incremental

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -41,9 +41,10 @@ jobs:
         run: node scripts/build-snapshot.mjs
         env:
           GITHUB_SHA: ${{ github.sha }}
-          # Enables Fix 3 enrichment (GitHub repo probe for Smithery rows).
-          # GITHUB_TOKEN is auto-provided per run, 1000 API req/hr unauth is the
-          # limit but Actions raises it via the token.
+          # Powers the Smithery repo-probe and archived-repo enrichment. The
+          # Actions-provided GITHUB_TOKEN is capped at ~1000 REST req/hr, so the
+          # archived-repo pass is incremental: capped per run, with flags
+          # carried across builds (see scripts/build-snapshot.mjs).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload to R2

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -127,6 +127,11 @@ function migrateSchema(db: Database.Database): void {
     // NULL = not checked yet, 0 = checked and clean, 1 = flagged.
     ['deprecated_npm', 'INTEGER DEFAULT NULL'],
     ['archived_repo', 'INTEGER DEFAULT NULL'],
+    // ISO timestamp of the last deprecation/archived probe. Drives the rolling
+    // re-probe window in enrichDeprecationFlags and is carried across snapshot
+    // rebuilds so probes stay incremental. NULL = never timestamped.
+    ['deprecated_npm_checked_at', 'TEXT DEFAULT NULL'],
+    ['archived_repo_checked_at', 'TEXT DEFAULT NULL'],
   ];
 
   for (const [col, def] of migrations) {

--- a/packages/core/src/enrich.ts
+++ b/packages/core/src/enrich.ts
@@ -15,6 +15,22 @@ export interface EnrichResult {
 }
 
 /**
+ * GitHub signals rate limiting with HTTP 403 or 429 plus either an exhausted
+ * `x-ratelimit-remaining: 0` header (primary limit) or a `retry-after` header
+ * (secondary / abuse limit). A 403 *without* those is a genuine error — a
+ * blocked, suspended, or DMCA'd repo — not a rate limit.
+ *
+ * The previous check tested the regex `/rate/i` against the *value* of
+ * `x-ratelimit-remaining`, which is always a number, so it never matched and
+ * every rate-limited 403 was miscounted as an error.
+ */
+function isGitHubRateLimited(res: Response): boolean {
+  if (res.status === 429) return true;
+  if (res.status !== 403) return false;
+  return res.headers.get('x-ratelimit-remaining') === '0' || res.headers.has('retry-after');
+}
+
+/**
  * For every Smithery-only row whose `qualifiedName` looks like `owner/name`
  * but has no `repository_url`, probe GitHub for `github.com/owner/name`. If
  * the repo exists, record the URL and try to merge with an existing row that
@@ -115,11 +131,7 @@ export async function enrichSmitheryRepoUrls(
     const repoUrl = `https://github.com/${item.owner}/${item.repo}`.toLowerCase();
     try {
       const res = await fetch(`https://api.github.com/repos/${item.owner}/${item.repo}`, { headers });
-      if (res.status === 403 && /rate/i.test(res.headers.get('x-ratelimit-remaining') ?? '')) {
-        stats.rateLimited++;
-        return;
-      }
-      if (res.status === 429) {
+      if (isGitHubRateLimited(res)) {
         stats.rateLimited++;
         return;
       }
@@ -191,37 +203,90 @@ export async function enrichSmitheryRepoUrls(
  *     whose repo is `archived`.
  *
  * Each row's `deprecated_npm` / `archived_repo` column becomes 0 (clean after
- * probe) or 1 (flagged). Rows still NULL after the pass were skipped (no
- * package identifier, no GitHub URL, or rate-limited / error). Meant to run in
- * the snapshot build job — unauthenticated GitHub gives 60 req/hr which would
- * blow up on 25k rows, so a `GITHUB_TOKEN` is strongly recommended.
+ * probe) or 1 (flagged), and `*_checked_at` records the probe time.
+ *
+ * The probe is incremental: a row is (re)probed only when it has never been
+ * flagged, has no probe timestamp, or its timestamp is older than the
+ * staleness window. Each pass is capped at `maxProbes` rows — the snapshot
+ * builder carries flags across rebuilds (see `carryOverFlags` in
+ * build-snapshot.mjs), so the whole corpus is refreshed on a rolling basis
+ * within the GitHub API budget instead of re-scanning 25k repos every run.
+ * A `GITHUB_TOKEN` is required for the archived-repo pass.
  */
 export interface DeprecationEnrichResult {
   npm: EnrichResult & { flagged: number };
   github: EnrichResult & { flagged: number };
 }
 
+/**
+ * Default rolling re-probe windows and per-run caps. GITHUB_MAX_PROBES stays
+ * under the Actions GITHUB_TOKEN budget (~1000 REST req/hr), and the modest
+ * default GitHub concurrency keeps the request rate under GitHub's per-minute
+ * secondary limit. At 4 runs/day the whole corpus refreshes well inside the
+ * 30-day window.
+ */
+const NPM_STALE_DAYS = 14;
+const NPM_MAX_PROBES = 4000;
+const GITHUB_STALE_DAYS = 30;
+const GITHUB_MAX_PROBES = 800;
+const GITHUB_CONCURRENCY = 4;
+
 export async function enrichDeprecationFlags(
   db: Database.Database,
-  opts: { token?: string; npmConcurrency?: number; githubConcurrency?: number; limit?: number } = {},
+  opts: {
+    token?: string;
+    npmConcurrency?: number;
+    githubConcurrency?: number;
+    npmStaleDays?: number;
+    githubStaleDays?: number;
+    npmMaxProbes?: number;
+    githubMaxProbes?: number;
+  } = {},
 ): Promise<DeprecationEnrichResult> {
   const token = opts.token ?? process.env.GITHUB_TOKEN;
   const npmConcurrency = Math.max(1, Math.min(opts.npmConcurrency ?? 24, 64));
-  const githubConcurrency = Math.max(1, Math.min(opts.githubConcurrency ?? 8, 16));
+  const githubConcurrency = Math.max(1, Math.min(opts.githubConcurrency ?? GITHUB_CONCURRENCY, 16));
 
-  const npm = await probeNpmDeprecations(db, { concurrency: npmConcurrency, limit: opts.limit });
-  const github = await probeGitHubArchived(db, { token, concurrency: githubConcurrency, limit: opts.limit });
+  const npm = await probeNpmDeprecations(db, {
+    concurrency: npmConcurrency,
+    staleDays: opts.npmStaleDays ?? NPM_STALE_DAYS,
+    maxProbes: opts.npmMaxProbes ?? NPM_MAX_PROBES,
+  });
+  const github = await probeGitHubArchived(db, {
+    token,
+    concurrency: githubConcurrency,
+    staleDays: opts.githubStaleDays ?? GITHUB_STALE_DAYS,
+    maxProbes: opts.githubMaxProbes ?? GITHUB_MAX_PROBES,
+  });
 
   return { npm, github };
 }
 
+/**
+ * Build the WHERE/ORDER/LIMIT tail shared by both deprecation probes: select
+ * rows whose flag is unknown, untimestamped, or stale, prioritising
+ * never-flagged rows, then never-timestamped, then the oldest timestamp.
+ */
+function staleSelectionClause(flagCol: string, checkedAtCol: string): string {
+  return `(
+           ${flagCol} IS NULL
+           OR ${checkedAtCol} IS NULL
+           OR ${checkedAtCol} < @cutoff
+         )
+       ORDER BY (${flagCol} IS NOT NULL),
+                (${checkedAtCol} IS NOT NULL),
+                ${checkedAtCol} ASC
+       LIMIT @maxProbes`;
+}
+
 async function probeNpmDeprecations(
   db: Database.Database,
-  opts: { concurrency: number; limit?: number },
+  opts: { concurrency: number; staleDays: number; maxProbes: number },
 ): Promise<EnrichResult & { flagged: number }> {
   const t0 = Date.now();
   const stats = { probed: 0, repoFound: 0, merged: 0, rateLimited: 0, errors: 0, durationMs: 0, flagged: 0 };
 
+  const cutoff = new Date(Date.now() - opts.staleDays * 86_400_000).toISOString();
   const rows = db
     .prepare(
       `SELECT id, package_identifier
@@ -229,21 +294,23 @@ async function probeNpmDeprecations(
        WHERE registry_type = 'npm'
          AND package_identifier IS NOT NULL
          AND package_identifier != ''
-         AND deprecated_npm IS NULL
-       ${opts.limit ? `LIMIT ${opts.limit}` : ''}`,
+         AND ${staleSelectionClause('deprecated_npm', 'deprecated_npm_checked_at')}`,
     )
-    .all() as Array<{ id: string; package_identifier: string }>;
+    .all({ cutoff, maxProbes: opts.maxProbes }) as Array<{ id: string; package_identifier: string }>;
 
-  stats.probed = rows.length;
   if (rows.length === 0) {
     stats.durationMs = Date.now() - t0;
     return stats;
   }
 
-  const update = db.prepare('UPDATE servers SET deprecated_npm = ? WHERE id = ?');
+  const update = db.prepare(
+    'UPDATE servers SET deprecated_npm = ?, deprecated_npm_checked_at = ? WHERE id = ?',
+  );
   const headers = { 'user-agent': 'mcpfinder-builder', accept: 'application/json' };
 
   async function probe(row: (typeof rows)[number]): Promise<void> {
+    stats.probed++;
+    const now = new Date().toISOString();
     try {
       const encoded = encodeURIComponent(row.package_identifier).replace(/%40/g, '@');
       const res = await fetch(`https://registry.npmjs.org/${encoded}`, { headers });
@@ -252,7 +319,7 @@ async function probeNpmDeprecations(
         return;
       }
       if (res.status === 404) {
-        update.run(1, row.id); // package gone from npm = treat as deprecated
+        update.run(1, now, row.id); // package gone from npm = treat as deprecated
         stats.flagged++;
         return;
       }
@@ -269,7 +336,7 @@ async function probeNpmDeprecations(
       const deprecated = Boolean(
         data.time?.unpublished || (latest && data.versions?.[latest]?.deprecated),
       );
-      update.run(deprecated ? 1 : 0, row.id);
+      update.run(deprecated ? 1 : 0, now, row.id);
       if (deprecated) stats.flagged++;
     } catch {
       stats.errors++;
@@ -296,7 +363,7 @@ async function probeNpmDeprecations(
 
 async function probeGitHubArchived(
   db: Database.Database,
-  opts: { token?: string; concurrency: number; limit?: number },
+  opts: { token?: string; concurrency: number; staleDays: number; maxProbes: number },
 ): Promise<EnrichResult & { flagged: number }> {
   const t0 = Date.now();
   const stats = { probed: 0, repoFound: 0, merged: 0, rateLimited: 0, errors: 0, durationMs: 0, flagged: 0 };
@@ -309,17 +376,16 @@ async function probeGitHubArchived(
     return stats;
   }
 
+  const cutoff = new Date(Date.now() - opts.staleDays * 86_400_000).toISOString();
   const rows = db
     .prepare(
       `SELECT id, repository_url
        FROM servers
        WHERE repository_url LIKE 'https://github.com/%'
-         AND archived_repo IS NULL
-       ${opts.limit ? `LIMIT ${opts.limit}` : ''}`,
+         AND ${staleSelectionClause('archived_repo', 'archived_repo_checked_at')}`,
     )
-    .all() as Array<{ id: string; repository_url: string }>;
+    .all({ cutoff, maxProbes: opts.maxProbes }) as Array<{ id: string; repository_url: string }>;
 
-  stats.probed = rows.length;
   if (rows.length === 0) {
     stats.durationMs = Date.now() - t0;
     return stats;
@@ -330,25 +396,34 @@ async function probeGitHubArchived(
     accept: 'application/vnd.github+json',
     'user-agent': 'mcpfinder-builder',
   };
-  const update = db.prepare('UPDATE servers SET archived_repo = ? WHERE id = ?');
+  const update = db.prepare(
+    'UPDATE servers SET archived_repo = ?, archived_repo_checked_at = ? WHERE id = ?',
+  );
+  // Once the API budget is exhausted, hammering the remaining rows just earns
+  // more 403s — stop launching probes and let the next run pick them up.
+  let rateLimitHit = false;
 
   async function probe(row: (typeof rows)[number]): Promise<void> {
+    const now = new Date().toISOString();
     const m = row.repository_url.match(/^https:\/\/github\.com\/([^/]+)\/([^/#?]+)/i);
-    if (!m) return;
+    if (!m) {
+      // Unparseable owner/repo — can't probe; mark clean + timestamped so the
+      // row ages out of the selection instead of being retried every run.
+      update.run(0, now, row.id);
+      return;
+    }
     const [, owner, repoRaw] = m;
     const repo = repoRaw.replace(/\.git$/, '');
+    stats.probed++;
     try {
       const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { headers });
-      if (res.status === 403 && /rate/i.test(res.headers.get('x-ratelimit-remaining') ?? '')) {
-        stats.rateLimited++;
-        return;
-      }
-      if (res.status === 429) {
+      if (isGitHubRateLimited(res)) {
+        rateLimitHit = true;
         stats.rateLimited++;
         return;
       }
       if (res.status === 404) {
-        update.run(1, row.id); // repo gone = treat as archived
+        update.run(1, now, row.id); // repo gone = treat as archived
         stats.flagged++;
         return;
       }
@@ -358,7 +433,7 @@ async function probeGitHubArchived(
       }
       const data = (await res.json()) as { archived?: boolean };
       const archived = Boolean(data.archived);
-      update.run(archived ? 1 : 0, row.id);
+      update.run(archived ? 1 : 0, now, row.id);
       if (archived) stats.flagged++;
     } catch {
       stats.errors++;
@@ -370,7 +445,7 @@ async function probeGitHubArchived(
   for (let w = 0; w < opts.concurrency; w++) {
     workers.push(
       (async () => {
-        while (idx < rows.length) {
+        while (idx < rows.length && !rateLimitHit) {
           const my = idx++;
           await probe(rows[my]);
         }

--- a/scripts/build-snapshot.mjs
+++ b/scripts/build-snapshot.mjs
@@ -24,7 +24,7 @@ import { createReadStream, createWriteStream } from 'node:fs';
 import { mkdir, rm, stat, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { pipeline } from 'node:stream/promises';
-import { createGzip } from 'node:zlib';
+import { createGzip, gunzipSync } from 'node:zlib';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -78,10 +78,69 @@ async function run(label, fn) {
   return n;
 }
 
+// Published snapshot, used as the persistent cache for incremental enrichment.
+const PREV_SNAPSHOT_URL = 'https://mcpfinder.dev/api/v1/snapshot/data.sqlite.gz';
+
+/**
+ * Seed deprecation/archived flags (and their probe timestamps) into the freshly
+ * built DB from the previously published snapshot, keyed by stable server id.
+ *
+ * The DB is rebuilt from scratch every run, so without this the enrichment
+ * probes would re-scan all ~25k repos each time and never finish within the
+ * GitHub API budget. Carrying flags forward makes `enrichDeprecationFlags`
+ * genuinely incremental — only new and stale rows get probed.
+ *
+ * Returns the number of rows seeded. Throws if the previous snapshot can't be
+ * fetched (e.g. the very first build) — the caller treats that as a soft skip.
+ */
+async function carryOverFlags(targetDb, workDir) {
+  const res = await fetch(PREV_SNAPSHOT_URL);
+  if (!res.ok) throw new Error(`fetch previous snapshot: HTTP ${res.status}`);
+  const prevPath = join(workDir, 'prev.sqlite');
+  await writeFile(prevPath, gunzipSync(Buffer.from(await res.arrayBuffer())));
+
+  targetDb.exec(`ATTACH DATABASE '${prevPath.replace(/'/g, "''")}' AS prev`);
+  try {
+    const prevCols = new Set(targetDb.pragma('prev.table_info(servers)').map((c) => c.name));
+    // Older snapshots predate the *_checked_at columns — carry whatever exists.
+    const cols = [
+      'archived_repo',
+      'archived_repo_checked_at',
+      'deprecated_npm',
+      'deprecated_npm_checked_at',
+    ].filter((c) => prevCols.has(c));
+    if (cols.length === 0) return 0;
+    const setClause = cols
+      .map((c) => `${c} = (SELECT p.${c} FROM prev.servers p WHERE p.id = servers.id)`)
+      .join(', ');
+    const info = targetDb
+      .prepare(`UPDATE servers SET ${setClause} WHERE id IN (SELECT id FROM prev.servers)`)
+      .run();
+    return info.changes;
+  } finally {
+    targetDb.exec('DETACH DATABASE prev');
+    await rm(prevPath, { force: true });
+  }
+}
+
 const counts = {};
 counts.official = await run('official', syncOfficialRegistry);
 if (!flag('--no-glama')) counts.glama = await run('glama   ', syncGlamaRegistry);
 if (!flag('--no-smithery')) counts.smithery = await run('smithery', syncSmitheryRegistry);
+
+// Carry deprecation/archived flags forward from the last published snapshot so
+// the enrichment probes stay incremental (skipped with --no-carryover).
+let carriedOver = 0;
+if (!flag('--no-carryover')) {
+  const c0 = Date.now();
+  try {
+    carriedOver = await carryOverFlags(db, outDir);
+    const cdt = ((Date.now() - c0) / 1000).toFixed(1);
+    console.log(`[build-snapshot] carry  : ${carriedOver} rows seeded from previous snapshot (${cdt}s)`);
+  } catch (err) {
+    console.warn(`[build-snapshot] carry  : skipped (${err?.message ?? err})`);
+  }
+}
 
 // Build-time enrichment passes (skipped with --no-enrich).
 let enrichStats = null;
@@ -137,6 +196,7 @@ const manifest = {
   url: 'data.sqlite.gz',
   builder: process.env.GITHUB_SHA || 'local',
   counts,
+  carriedOver,
   enrich: enrichStats,
   deprecation: deprecationStats,
 };


### PR DESCRIPTION
## Problem

The latest snapshot manifest showed the GitHub archived-repo probe failing badly: **20,626 errors out of 25,382 probes** (~81%), with `rateLimited: 0`.

Two root causes:

1. **Broken rate-limit detection** — `probeGitHubArchived` tested the regex `/rate/i` against the *value* of the `x-ratelimit-remaining` header, which is always a number. It never matched, so every rate-limited `403` fell through to the error branch.
2. **No carry-over between runs** — `build-snapshot.mjs` rebuilds the DB from scratch every run, so `archived_repo`/`deprecated_npm` started `NULL` for all ~25k rows. The `... IS NULL` incremental query had nothing to skip and tried to probe every repo, exhausting the `GITHUB_TOKEN` budget (~1000 req/hr) within seconds. ~80% of servers shipped without a flag every snapshot.

## Fix

- **`isGitHubRateLimited()`** helper checks `x-ratelimit-remaining: 0` and the `retry-after` header (primary + secondary limits); applied to both GitHub probes.
- New **`deprecated_npm_checked_at` / `archived_repo_checked_at`** columns. Probes now select rows that are unflagged, untimestamped, or stale, capped per run (npm 4000 / 14-day window, GitHub 800 / 30-day window).
- **`carryOverFlags()`** in `build-snapshot.mjs` seeds flags + timestamps from the previously published snapshot (keyed by stable server id), making the probes genuinely incremental across rebuilds.
- **Early-stop** the GitHub pass once rate-limited; default GitHub concurrency lowered to 4 to stay under the per-minute secondary limit.
- Unparseable GitHub URLs are marked clean + timestamped so they age out of the selection instead of being retried forever.

## Effect

- `deprecation.github.errors` drops from ~20,600 → ~0; real rate-limits land in `rateLimited`.
- GitHub probes: 25,382/run → max 800/run (~3,200/day) — whole corpus gets a timestamp in ~8 days, then rolling 30-day refresh, comfortably within budget.
- `archived_repo`/`deprecated_npm` flags stop disappearing between snapshots.

## Verification

- `pnpm test` (build core + server, contract tests, core-capability tests) — pass.
- npm incremental selection (new/stale/fresh/cap) — 14 assertions, pass.
- GitHub probe path against a live token (live/404/archived/malformed, timestamps, second-run no-op) — 9 assertions, pass.
- `carryOverFlags` SQL exercised against the live production snapshot — pass.

Build-pipeline only — no npm package release required; the improvement reaches clients via the next scheduled snapshot.