### PR TITLE
fix(core): timeout, retry, and wall-clock budget for registry sync

### DIFF
--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -21,9 +21,63 @@ const GLAMA_BASE = 'https://glama.ai/api/mcp/v1';
 const SMITHERY_BASE = 'https://registry.smithery.ai';
 const PAGE_LIMIT = 100;
 
+/** Per-request timeout and retry policy for registry fetches. */
+const REQUEST_TIMEOUT_MS = 20_000;
+const REQUEST_RETRIES = 3;
+
+/**
+ * Wall-clock budget per registry. A degraded upstream that keeps responding
+ * just slowly enough to dodge the per-request timeout still can't drag the
+ * snapshot build into its 45-minute CI ceiling. Official overrun fails the
+ * build (a snapshot missing Official servers is worse than no new snapshot);
+ * Glama/Smithery overrun ships a best-effort partial, matching their existing
+ * error handling.
+ */
+const OFFICIAL_SYNC_BUDGET_MS = 8 * 60_000;
+const GLAMA_SYNC_BUDGET_MS = 12 * 60_000;
+const SMITHERY_SYNC_BUDGET_MS = 5 * 60_000;
+
 /** Delay helper for rate limiting */
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * `fetch()` with a per-request timeout and bounded retries. Retries on network
+ * errors, aborts (timeout), HTTP 429, and 5xx using exponential backoff; 4xx
+ * and success are returned as-is for the caller to handle. Throws once retries
+ * are exhausted, so a hung or failing upstream surfaces fast instead of
+ * blocking indefinitely.
+ */
+async function fetchWithRetry(
+  url: string,
+  opts: { timeoutMs?: number; retries?: number; label?: string } = {},
+): Promise<Response> {
+  const timeoutMs = opts.timeoutMs ?? REQUEST_TIMEOUT_MS;
+  const retries = opts.retries ?? REQUEST_RETRIES;
+  const label = opts.label ?? 'registry fetch';
+  let lastErr: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) await delay(500 * 3 ** (attempt - 1)); // 0.5s, 1.5s, 4.5s
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      clearTimeout(timer);
+      // Retry transient server-side failures; return everything else (incl. 4xx).
+      if (res.status === 429 || res.status >= 500) {
+        lastErr = new Error(`HTTP ${res.status}`);
+        continue;
+      }
+      return res;
+    } catch (err) {
+      clearTimeout(timer);
+      lastErr = err;
+    }
+  }
+  const reason = lastErr instanceof Error ? lastErr.message : String(lastErr);
+  throw new Error(`${label}: giving up after ${retries + 1} attempts — ${reason}`);
 }
 
 /**
@@ -129,6 +183,7 @@ export async function syncOfficialRegistry(db: Database.Database): Promise<numbe
 
   let cursor: string | null = null;
   let totalUpserted = 0;
+  const deadline = Date.now() + OFFICIAL_SYNC_BUDGET_MS;
 
   const upsert = db.prepare(`
     INSERT INTO servers (
@@ -162,13 +217,20 @@ export async function syncOfficialRegistry(db: Database.Database): Promise<numbe
   `);
 
   do {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Official registry sync exceeded its ${OFFICIAL_SYNC_BUDGET_MS / 60_000}-minute budget ` +
+          `(upstream too slow) — aborting after ${totalUpserted} servers`,
+      );
+    }
+
     const url = new URL(`${REGISTRY_BASE}/v0.1/servers`);
     url.searchParams.set('version', 'latest');
     url.searchParams.set('limit', String(PAGE_LIMIT));
     if (lastSync) url.searchParams.set('updated_since', lastSync);
     if (cursor) url.searchParams.set('cursor', cursor);
 
-    const res = await fetch(url.toString());
+    const res = await fetchWithRetry(url.toString(), { label: 'Registry API' });
     if (!res.ok) {
       const errText = await res.text().catch(() => '');
       throw new Error(`Registry API error: ${res.status} ${res.statusText} — ${errText}`);
@@ -257,6 +319,7 @@ function normalizeGlamaEntry(entry: GlamaServer) {
 export async function syncGlamaRegistry(db: Database.Database): Promise<number> {
   let cursor: string | null = null;
   let totalUpserted = 0;
+  const deadline = Date.now() + GLAMA_SYNC_BUDGET_MS;
 
   const upsert = db.prepare(`
     INSERT INTO servers (
@@ -282,11 +345,18 @@ export async function syncGlamaRegistry(db: Database.Database): Promise<number> 
 
   try {
     do {
+      if (Date.now() > deadline) {
+        process.stderr.write(
+          `[mcpfinder] Glama sync budget exceeded — stopping with ${totalUpserted} servers\n`,
+        );
+        break;
+      }
+
       const url = new URL(`${GLAMA_BASE}/servers`);
       url.searchParams.set('first', String(PAGE_LIMIT));
       if (cursor) url.searchParams.set('after', cursor);
 
-      const res = await fetch(url.toString());
+      const res = await fetchWithRetry(url.toString(), { label: 'Glama API' });
       if (!res.ok) {
         const errText = await res.text().catch(() => '');
         throw new Error(`Glama API error: ${res.status} ${res.statusText} — ${errText}`);
@@ -389,6 +459,7 @@ export async function syncSmitheryRegistry(db: Database.Database): Promise<numbe
   let page = 1;
   let totalUpserted = 0;
   let hasMore = true;
+  const deadline = Date.now() + SMITHERY_SYNC_BUDGET_MS;
 
   const upsert = db.prepare(`
     INSERT INTO servers (
@@ -416,11 +487,18 @@ export async function syncSmitheryRegistry(db: Database.Database): Promise<numbe
 
   try {
     while (hasMore) {
+      if (Date.now() > deadline) {
+        process.stderr.write(
+          `[mcpfinder] Smithery sync budget exceeded — stopping with ${totalUpserted} servers\n`,
+        );
+        break;
+      }
+
       const url = new URL(`${SMITHERY_BASE}/servers`);
       url.searchParams.set('page', String(page));
       url.searchParams.set('pageSize', String(PAGE_LIMIT));
 
-      const res = await fetch(url.toString());
+      const res = await fetchWithRetry(url.toString(), { label: 'Smithery API' });
       if (!res.ok) {
         const errText = await res.text().catch(() => '');
         throw new Error(`Smithery API error: ${res.status} ${res.statusText} — ${errText}`);


### PR DESCRIPTION
## Problem

A manual snapshot build (`workflow_dispatch`) hit the **45-minute CI ceiling** and was cancelled. The run log showed exactly one progress line:

```
[build-snapshot] official: +9315 (2243.4s, total=9315)
```

The Official registry sync alone took **37 minutes** — `registry.modelcontextprotocol.io` was responding ~24s/page instead of ~0.8s/page. The job was then cancelled mid-Glama-sync.

The registry fetches had **no timeout and no retry**. A slow or hung upstream could stall the build indefinitely. Note a plain per-request timeout *alone* wouldn't have caught this run — each slow page still completed (just slowly, ~24s).

This is independent of #4 — the enrichment fix runs after sync and never executed in the failed run.

## Fix

- **`fetchWithRetry()`** — per-request timeout via `AbortController` (20s) plus bounded retries (3) with exponential backoff (0.5s/1.5s/4.5s) on network errors, aborts, `429`, and `5xx`. Used by all three registry syncs.
- **Per-registry wall-clock budget** — Official 8 min, Glama 12 min, Smithery 5 min:
  - Official overrun **throws** → build fails fast (a snapshot missing Official servers is worse than no new snapshot; the previous good snapshot stays live in R2).
  - Glama/Smithery overrun stops paginating and ships a **best-effort partial**, matching their existing catch-and-continue handling.

Net effect: a degraded upstream now fails the build in ~1-2 min or yields a partial, instead of hanging until the 45-min timeout.

## Verification

Offline, driving `syncOfficialRegistry` with a mocked global `fetch` / `Date.now` — 9 assertions, all pass:

- retry recovers from transient network errors (2 fail → 1 ok)
- retry recovers from HTTP 503
- persistent failure gives up after exactly 4 attempts, in <15s (no hang)
- per-registry budget aborts a slow-but-working upstream (the exact failure mode above)
- happy path unchanged (one page, one fetch)

Plus `pnpm test` (build core + server, contract tests, core-capability tests incl. a real sync) — pass.

Build-pipeline resilience only — no npm package release required.