### PR TITLE
SEO: mcpfinder.dev — wpleć 'search' w title/meta dla CTR na frazach brandowych

### DIFF
--- a/landing/public/index.html
+++ b/landing/public/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MCPfinder | Discover and Install MCP Servers</title>
-  <meta name="description" content="AI-first MCP server discovery across Official Registry, Glama, and Smithery. Inspect trust signals, tools and env vars, then generate install config for Claude, Cursor, Claude Code, Cline, and Windsurf.">
+  <title>MCPfinder | Search, Discover & Install MCP Servers</title>
+  <meta name="description" content="Search and discover MCP servers across the Official Registry, Glama, and Smithery. Inspect trust signals, tools and env vars, then generate install config for Claude, Cursor, Claude Code, Cline, and Windsurf.">
   <meta name="keywords" content="MCP discovery, MCP server install, AI agent tooling, Model Context Protocol, MCP server registry, Claude Desktop MCP, Cursor MCP">
   <meta name="author" content="Coder AI">
   <meta name="robots" content="index, follow">
@@ -20,7 +20,7 @@
   <!-- Open Graph -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://mcpfinder.dev/">
-  <meta property="og:title" content="MCPfinder | MCP Server Discovery for AI Agents">
+  <meta property="og:title" content="MCPfinder | Search & Discover MCP Servers for AI Agents">
   <meta property="og:description" content="Search MCP servers across multiple registries, inspect trust signals, and generate install-ready config for your AI client.">
   <meta property="og:image" content="https://mcpfinder.dev/mcpfinder-icon.png">
   <meta property="og:image:width" content="512">
@@ -36,7 +36,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@coderaidev">
-  <meta name="twitter:title" content="MCPfinder | MCP Server Discovery for AI Agents">
+  <meta name="twitter:title" content="MCPfinder | Search & Discover MCP Servers for AI Agents">
   <meta name="twitter:description" content="Search MCP servers across multiple registries, inspect trust signals, and generate install-ready config for your AI client.">
   <meta name="twitter:image" content="https://mcpfinder.dev/mcpfinder-icon.png">
   <meta name="twitter:image:alt" content="MCPfinder logo — a lime-yellow lightning bolt on a black background.">


### PR DESCRIPTION
## Kontekst
Rekomendacje SEO (dziennik 2026-07-01) dla domeny **mcpfinder.dev**. Brandowe/near-brand frazy **\"mcp finder\"** (poz. ~6) i **\"mcpfinder\"** (poz. ~2) mają CTR = 0 mimo pozycji tuż pod topem — sygnał problemu ze snippetem (title/description), nie z rankingiem. Klaster popytu jest spójny wokół *search / discovery / directory / explorer* serwerów MCP.

## Zmiany (tylko meta strony głównej — landing/public/index.html)
- `<title>`: `Discover and Install MCP Servers` → **`Search, Discover & Install MCP Servers`** — dokłada dokładny keyword \"search\" z klastra, brand nadal na początku.
- `<meta name=\"description\">`: otwiera akcją intencyjną — `Search and discover MCP servers across the Official Registry, Glama, and Smithery...` (wcześniej `AI-first MCP server discovery...`).
- `og:title` + `twitter:title`: `MCP Server Discovery for AI Agents` → **`Search & Discover MCP Servers for AI Agents`** (spójność social snippetów).

Diff to 4 linie; żadnej zmiany logiki produktu, treści ani struktury strony.

## Świadomie pominięto (poza bezpieczną powierzchnią SEO / wymaga decyzji produktowej)
- Reko #2: dedykowana landing/hub pod \"discover MCP servers\" — nowa podstrona.
- Reko #4: redirecty/wewnętrzne linki dla \"mcpfind\" — konfiguracja infra/routingu.
- Reko #5: blog / README-driven content — nowa treść.

Draft do przeglądu maintainera.