### PR TITLE
fix: raise Glama snapshot budget for current corpus

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -26,9 +26,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Registry budgets can consume 43 minutes; keep at least 47 minutes for
-    # install, focused tests, enrichment, vacuum/gzip, preflight, and upload.
-    timeout-minutes: 90
+    # Glama alone currently needs about an hour to enumerate its full corpus;
+    # keep another hour for install, tests, enrichment, packaging, and upload.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v6
 
@@ -54,9 +54,10 @@ jobs:
           # Manual-only escape hatch for an intentional corpus reset. It does
           # not bypass missing/error source status checks.
           MCPFINDER_SNAPSHOT_QUALITY_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_quality_regression && '1' || '0' }}
-          # Glama has repeatedly needed more than the 12-minute local budget.
-          # Thirty minutes leaves headroom inside the 90-minute job ceiling.
-          MCPFINDER_GLAMA_SYNC_BUDGET_MINUTES: '30'
+          # Glama's corpus has outgrown the old 30-minute budget. Keep this a
+          # bounded full sync so publication never trades freshness for a
+          # silent partial dataset.
+          MCPFINDER_GLAMA_SYNC_BUDGET_MINUTES: '90'
           # Powers the Smithery repo-probe and archived-repo enrichment. The
           # Actions-provided GITHUB_TOKEN is capped at ~1000 REST req/hr, so the
           # archived-repo pass is incremental: capped per run, with flags

--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ For an intentional corpus reset, manually dispatch the snapshot workflow with
 never permits an errored or incomplete required source.
 
 Glama keeps a 12-minute sync budget for normal local stdio use. The scheduled
-snapshot job sets `MCPFINDER_GLAMA_SYNC_BUDGET_MINUTES=30` because a full Glama
-pagination regularly exceeds the local limit, while still leaving headroom
-inside the job's 90-minute timeout. Custom values must be whole minutes from 1
-through 40. HTTP 200 pages with truncated or malformed JSON are retried on the
+snapshot job sets `MCPFINDER_GLAMA_SYNC_BUDGET_MINUTES=90` because a full Glama
+pagination has outgrown the old 30-minute limit, while still remaining bounded
+inside the job's 150-minute timeout. Custom values must be whole minutes from 1
+through 120. HTTP 200 pages with truncated or malformed JSON are retried on the
 same cursor before the source is marked as errored. The hard registry deadline
 covers the terminal response body as well as transport and parsing: a page that
 finishes after the budget is deliberately marked degraded, protecting the

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -72,8 +72,8 @@ only the count-regression check with `--allow-quality-regression` or
 
 `MCPFINDER_GLAMA_SYNC_BUDGET_MINUTES` can raise Glama's default 12-minute
 wall-clock budget for batch builds. It accepts integer values from 1 through
-40; invalid or unbounded values fail explicitly. The snapshot workflow uses 30
-minutes within its 90-minute job timeout. Malformed HTTP 200 JSON pages are
+120; invalid or unbounded values fail explicitly. The snapshot workflow uses 90
+minutes within its 150-minute job timeout. Malformed HTTP 200 JSON pages are
 retried at the same cursor before the sync records an error. The hard registry
 budget includes consuming and parsing the terminal response body; a page that
 finishes after its deadline is intentionally degraded rather than accepted as

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -31,7 +31,7 @@ const PAGE_LIMIT = 100;
 /**
  * Wall-clock budget per registry. A degraded upstream that keeps responding
  * just slowly enough to dodge the per-request timeout still can't drag the
- * snapshot build into its 90-minute CI ceiling. Official overrun fails the
+ * snapshot build into its CI ceiling. Official overrun fails the
  * build (a snapshot missing Official servers is worse than no new snapshot);
  * Glama/Smithery overrun keeps the best-effort partial data for resilient
  * local use, but records a degraded sync_log status so snapshot publication
@@ -39,12 +39,12 @@ const PAGE_LIMIT = 100;
  */
 const OFFICIAL_SYNC_BUDGET_MS = 8 * 60_000;
 const DEFAULT_GLAMA_SYNC_BUDGET_MINUTES = 12;
-const MAX_GLAMA_SYNC_BUDGET_MINUTES = 40;
+const MAX_GLAMA_SYNC_BUDGET_MINUTES = 120;
 const SMITHERY_SYNC_BUDGET_MS = 5 * 60_000;
 
 /**
  * Keep local stdio behavior at the historical 12-minute limit while allowing
- * the snapshot job to reserve more of its 90-minute ceiling for Glama. Reject
+ * the snapshot job to reserve more time for Glama's growing corpus. Reject
  * invalid values instead of silently turning a typo into an unbounded sync.
  */
 function getGlamaSyncBudgetMinutes(): number {

--- a/scripts/test-snapshot-artifacts.mjs
+++ b/scripts/test-snapshot-artifacts.mjs
@@ -191,7 +191,7 @@ assert.ok(
     durableFallback > manifestUpload &&
     durableProof > durableFallback,
 );
-assert.match(workflow, /timeout-minutes: 90/);
+assert.match(workflow, /timeout-minutes: 150/);
 assert.doesNotMatch(workflow, /run: pnpm test(?:\s|$)/);
 assert.doesNotMatch(workflow, /check:types/);
 

--- a/scripts/test-snapshot-quality.mjs
+++ b/scripts/test-snapshot-quality.mjs
@@ -180,7 +180,7 @@ try {
   smitheryStructureDb.close();
 
   // Valid and invalid Glama budget configuration both leave auditable state.
-  process.env.MCPFINDER_GLAMA_SYNC_BUDGET_MINUTES = '30';
+  process.env.MCPFINDER_GLAMA_SYNC_BUDGET_MINUTES = '90';
   const overrideDb = initDatabase(join(dir, 'override.sqlite'));
   let overrideCalls = 0;
   const overrideTimes = [0, 20 * 60_000];
@@ -199,7 +199,7 @@ try {
   const invalidBudgetDb = initDatabase(join(dir, 'invalid-budget.sqlite'));
   assert.equal(await syncGlamaRegistry(invalidBudgetDb, runtime(async () => Response.json(glamaEmpty))), 0);
   assert.equal(syncLog(invalidBudgetDb, 'glama').status, 'error');
-  assert.match(syncLog(invalidBudgetDb, 'glama').error, /integer between 1 and 40/);
+  assert.match(syncLog(invalidBudgetDb, 'glama').error, /integer between 1 and 120/);
   invalidBudgetDb.close();
   if (originalGlamaBudget === undefined) delete process.env.MCPFINDER_GLAMA_SYNC_BUDGET_MINUTES;
   else process.env.MCPFINDER_GLAMA_SYNC_BUDGET_MINUTES = originalGlamaBudget;


### PR DESCRIPTION
Closes #8.

The latest scheduled run synced 39,400 Glama records in 30 minutes before the bounded quality gate correctly rejected the partial source. Glama now advertises 76k+ servers, so the previous budget cannot complete a full traversal at the observed rate.

This keeps the existing fail-closed publication semantics and full-source quality gates, while raising:
- the scheduled Glama budget from 30 to 90 minutes
- the validated maximum override from 40 to 120 minutes
- the workflow timeout from 90 to 150 minutes

Docs and assertions are updated accordingly. No partial-data fallback or regression override is introduced.

Validation:
- `pnpm test`
- `git diff --check`